### PR TITLE
feat: add Google Analytics 4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mdx-js/loader": "^3.0.0",
         "@mdx-js/react": "^3.0.0",
         "@next/mdx": "^14.0.4",
+        "@next/third-parties": "^16.1.6",
         "@tailwindcss/typography": "^0.5.4",
         "@types/node": "^20.10.8",
         "@types/react": "^18.2.47",
@@ -1060,6 +1061,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.1.6.tgz",
+      "integrity": "sha512-/cLY1egaH529ylSMSK+C8dA3nWDLL4hOFR4fca9OLWWxjcNwzsbuq2pPb/tmdWL9Zj3K1nTjd1pWQoSlaDQ0VA==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -7610,6 +7624,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@mdx-js/loader": "^3.0.0",
     "@mdx-js/react": "^3.0.0",
     "@next/mdx": "^14.0.4",
+    "@next/third-parties": "^16.1.6",
     "@tailwindcss/typography": "^0.5.4",
     "@types/node": "^20.10.8",
     "@types/react": "^18.2.47",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from 'next'
+import { GoogleAnalytics } from '@next/third-parties/google'
 
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
@@ -34,6 +35,9 @@ export default function RootLayout({
           </div>
         </Providers>
       </body>
+      {process.env.NEXT_PUBLIC_GA_ID && (
+        <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GA_ID} />
+      )}
     </html>
   )
 }


### PR DESCRIPTION
Adds GA4 to austinnchristensen.com.

## Setup
1. Merge this PR
2. Add `NEXT_PUBLIC_GA_ID=G-L3BC359RBJ` to Vercel env vars
3. Deploy — done

## Implementation
- Uses `@next/third-parties/google` (same pattern as BCH)
- Env-gated — no-op if `NEXT_PUBLIC_GA_ID` is not set

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a third-party analytics script to the global `RootLayout`, which changes client-side behavior on every page when `NEXT_PUBLIC_GA_ID` is set. Risk is mainly around unintended tracking/performance implications and correct environment configuration.
> 
> **Overview**
> Adds Google Analytics 4 integration using `@next/third-parties/google`, gated by `NEXT_PUBLIC_GA_ID` so analytics is only injected when configured.
> 
> Updates dependencies/lockfile to include `@next/third-parties` (and `third-party-capital`) to support this GA4 embed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2fe7f2118415db404d74991dd679a8111ceb298. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->