### PR TITLE
fix: remove employer names from public copy, personalize site content

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -69,7 +69,7 @@ export default function About() {
                     </h1>
                     <div className="mt-6 space-y-7 text-base text-zinc-600 dark:text-zinc-400">
                         <p>
-                            I&apos;m a full-stack software engineer with a decade of experience building web applications at scale. I currently work at Hyatt and Costco, where I lead feature development across complex, high-traffic systems.
+                            I&apos;m a full-stack software engineer with a decade of experience building web applications at scale. I work across large enterprise systems and my own software products.
                         </p>
                         <p>
                             Outside of my day job, I build and ship my own software products. I founded Smart Locker USA, a SaaS platform for meat processors that I grew and sold. These days I&apos;m focused on Backcountry Hunter, a gear management app for hunters and backcountry athletes, and Points Mafia, a newsletter and toolset for travel rewards enthusiasts.

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -41,7 +41,7 @@ function LinkIcon(props: React.ComponentPropsWithoutRef<'svg'>) {
 
 export const metadata: Metadata = {
   title: 'Projects',
-  description: 'Software products I've built — from SaaS exits to apps still in the wild.',
+  description: 'Software products I have built -- from SaaS exits to apps still in the wild.',
 }
 
 export default function Projects() {

--- a/src/content/homePageContent.ts
+++ b/src/content/homePageContent.ts
@@ -1,4 +1,4 @@
 export const homePageHeader = {
     title: 'Software developer, founder, and outdoor enthusiast.',
-    content: "I'm Austin, a software engineer and entrepreneur based in Salt Lake City. I build products at Hyatt and Costco by day, and ship my own software businesses in the time I carve out between those and the mountains."
+    content: "I'm Austin, a software engineer and entrepreneur based in Salt Lake City. I build enterprise software by day and ship my own products in the time I carve out between that and the mountains."
 }


### PR DESCRIPTION
- Remove Hyatt and Costco from about page and homepage header
- Replace with generic 'enterprise software / large-scale systems' language
- Fix curly apostrophe TS errors in projects page metadata
- All employer names scrubbed from public-facing copy